### PR TITLE
content: fix dates by adding time

### DIFF
--- a/content/home/publications.md
+++ b/content/home/publications.md
@@ -3,7 +3,7 @@
 # This widget displays recent publications from `content/publication/`.
 widget = "publications"
 active = true
-date = 2016-04-20
+date = 2016-04-20T00:00:00Z
 
 title = "Recent Publications"
 subtitle = ""

--- a/content/home/publications_selected.md
+++ b/content/home/publications_selected.md
@@ -4,7 +4,7 @@
 # `selected = true` in their `+++` front matter.
 widget = "publications_selected"
 active = true
-date = 2016-04-20
+date = 2016-04-20T00:00:00Z
 
 title = "Selected Publications"
 subtitle = ""

--- a/content/home/tags.md
+++ b/content/home/tags.md
@@ -2,7 +2,7 @@
 # Tag Cloud widget.
 widget = "tag_cloud"
 active = true
-date = 2017-09-20
+date = 2017-09-20T00:00:00Z
 
 title = "Tags"
 subtitle = ""

--- a/content/post/_index.md
+++ b/content/post/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Posts"
-date = 2017-01-01
+date = 2017-01-01T00:00:00Z
 math = false
 highlight = false
 


### PR DESCRIPTION
Running hugo 0.30.2 fails with an error on the format of the date. Fix this by adding T00:00:00Z time to the date.

I have been running this on Fedora 27 with the default off-the-repo Hugo version on a clean checkout.