### PR TITLE
Add summaryLength site variable

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,9 @@ ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
 preserveTaxonomyNames = true
 paginate = 10
 
+# The length of summaries, Hugo's default is 70
+summaryLength = 70
+
 # Enable comments by entering your Disqus shortname
 disqusShortname = ""
 


### PR DESCRIPTION
Addresses issue: Add summaryLength variable to config.toml #11