### PR TITLE
Fix hugo version for deploy preview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
   publish = "public"
   command = "hugo"
 
+[context.deploy-preview.environment]
+  HUGO_VERSION = "0.50"
+  HUGO_ENABLEGITINFO = "true"
+
 [context.production.environment]
   HUGO_VERSION = "0.50"
   HUGO_ENV = "production"


### PR DESCRIPTION
Otherwise deploy-previews fail since the default netlify hugo version is <0.50