### PR TITLE
Block search engines from indexing non-production sites

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -39,6 +39,8 @@ enableEmoji = true
 footnotereturnlinkcontents = "<sup>^</sup>"
 ignoreFiles = ["\\.ipynb$", ".ipynb_checkpoints$", "\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
 
+enableRobotsTXT = true
+
 [outputs]
   home = [ "HTML", "RSS", "JSON" ]
   section = [ "HTML", "RSS" ]

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: {{ if ne (getenv "HUGO_ENV") "production" }}/{{ end }}


### PR DESCRIPTION
This will enable to generate a robots.txt file to block (some) search engines from indexing sites that are not running in production environment (e.g. system environment variable `HUGO_ENV` is unset or not `production`).

This will be straight forward on Netlify as `HUGO_ENV` is set in `netlify.toml`. For other hosters, the documentation should mention this to the user to either set `HUGO_ENV=production` during build or disable robots.txt generation.