### PR TITLE
Fix sed inplace option to run with both GNU and OSX sed

### DIFF
--- a/update_academic.sh
+++ b/update_academic.sh
@@ -20,7 +20,7 @@ function install_update () {
   # - Update Netlify.toml with required Hugo version
   if [ -f ./netlify.toml ]; then
     version=$(sed -n 's/^min_version = //p' themes/academic/theme.toml)
-    sed -i '' -e "s/HUGO_VERSION = .*/HUGO_VERSION = $version/g" ./netlify.toml
+    sed -i.bak -e "s/HUGO_VERSION = .*/HUGO_VERSION = $version/g" ./netlify.toml && rm -f ./netlify.toml.bak
   fi
 
   echo


### PR DESCRIPTION
The sed 'inplace' argument used in the update script seems to be specific to OSX sed and the script complains "sed: can't read : No such file or directory" when running GNU sed used by Linux distributions. I assume an explicit creation of the backup file then removing it will make both systems happy. Only tested with GNU sed, can a OSX user confirm this workaround is ok ?