### PR TITLE
gitignore: ignore the resources folder in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/
 .idea/
+resources/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-public/
+# IDEs
 .idea/
+
+# Hugo
 resources/
+public/


### PR DESCRIPTION
When I run the `hugo server` command, a `resources` folder is created.

I believe this folder contains automatically-generated files that should be ignored when making commits to the repo.

I added it to the `.gitignore`