### PR TITLE
fix folder ambiguity caused by typos

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -42,7 +42,7 @@ ignoreFiles = ["\\.ipynb$", ".ipynb_checkpoints$", "\\.Rmd$", "\\.Rmarkdown$", "
   authors = "/author/:slug/"
   tags = "/tag/:slug/"
   categories = "/category/:slug/"
-  publication_types = "/publication-type/:slug/"
+  publication_types = "/publication_type/:slug/"
 
 [outputs]
   home = [ "HTML", "RSS", "JSON", "WebAppManifest" ]
@@ -73,7 +73,7 @@ ignoreFiles = ["\\.ipynb$", ".ipynb_checkpoints$", "\\.Rmd$", "\\.Rmarkdown$", "
 
 # Taxonomies.
 [taxonomies]
-  tag = "tags"
-  category = "categories"
-  publication_type = "publication_types"
-  author = "authors"
+  tag = "tag"
+  category = "category"
+  publication_type = "publication_type"
+  author = "author"


### PR DESCRIPTION
In commit https://github.com/sourcethemes/academic-kickstart/commit/47c949aa3c0a687a3c7a70f0d697d147c6196654#diff-9804740ad4c28c388e289183da5d17c4, the taxonomy terms are changed into singular.

It causes several issues:
1.  variables under [taxonomies] are still plurals. Thus the taxonomy folders are not consistent.
![Snipaste_2020-05-22_08-54-02](https://user-images.githubusercontent.com/64292488/82675508-8b5dae80-9c0a-11ea-907f-b4e7a313f3f5.png)
2.  I guess "publication-type" is a typo. It generate the "publication-type" folder. However, the correct folder should be "publication_type".